### PR TITLE
Fixes crash when the WireGuard Go library invokes the log callback

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   create_release:
     name: Create Release
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - uses: actions/setup-go@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ wg-go-framework: wg-go-iphoneos wg-go-iphonesimulator
 		cp Sources/WireGuardKitGo/out/$$id/libwg-go.a Sources/WireGuardKitGo/out/$$id/WireGuardKitGo.framework/WireGuardKitGo ; \
 		cp -R Sources/WireGuardKitGo/.tmp/Headers Sources/WireGuardKitGo/out/$$id/WireGuardKitGo.framework ; \
 		cp -R Sources/WireGuardKitGo/.tmp/Modules Sources/WireGuardKitGo/out/$$id/WireGuardKitGo.framework ; \
+		cp Sources/WireGuardKitGo/Info.plist Sources/WireGuardKitGo/out/$$id/WireGuardKitGo.framework ; \
 	done
 
 	xcodebuild -create-xcframework \

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "WireGuardKitGo",
-            url: "https://github.com/battlmonstr/wireguard-apple/releases/download/1.0.15.13/WireGuardKitGo.xcframework.zip",
-            checksum: "c01d7c8d2523f23f1287871af482c3c464e0a9a6062445e036995fbdedb93498"
+            url: "https://github.com/operasoftware/wireguard-apple/releases/download/1.0.15.15/WireGuardKitGo.xcframework.zip",
+            checksum: "2b25a9218c693c2d131d0c00303d15340ffe8ad68e20e0ef7a20b287781050c2"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "WireGuardKitGo",
-            url: "https://github.com/operasoftware/wireguard-apple/releases/download/1.0.15.15/WireGuardKitGo.xcframework.zip",
-            checksum: "2b25a9218c693c2d131d0c00303d15340ffe8ad68e20e0ef7a20b287781050c2"
+            url: "https://github.com/operasoftware/wireguard-apple/releases/download/1.0.16.1/WireGuardKitGo.xcframework.zip",
+            checksum: "7a332aadff000091f68e7a5ab00c7b40a0b2dc9a90c3336a0b4165a99a1b8593"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "WireGuardKit",
     platforms: [
         .macOS(.v10_14),
-        .iOS(.v14)
+        .iOS(.v15)
     ],
     products: [
         .library(name: "WireGuardKit", targets: ["WireGuardKit"])
@@ -25,8 +25,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "WireGuardKitGo",
-            url: "https://github.com/operasoftware/wireguard-apple/releases/download/1.0.16.2/WireGuardKitGo.xcframework.zip",
-            checksum: "4a9b3aa1954ca02457328c988a3e40848bf5c5b35674a58fbe55b08a9d4ac8d4"
+            url: "https://github.com/operasoftware/wireguard-apple/releases/download/1.0.16.3/WireGuardKitGo.xcframework.zip",
+            checksum: "ce71499d16ec668468bb1c53fc10176a26be5341c12157e4026c22e0a2194b1b"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "WireGuardKitGo",
-            url: "https://github.com/operasoftware/wireguard-apple/releases/download/1.0.16.1/WireGuardKitGo.xcframework.zip",
-            checksum: "7a332aadff000091f68e7a5ab00c7b40a0b2dc9a90c3336a0b4165a99a1b8593"
+            url: "https://github.com/operasoftware/wireguard-apple/releases/download/1.0.16.2/WireGuardKitGo.xcframework.zip",
+            checksum: "4a9b3aa1954ca02457328c988a3e40848bf5c5b35674a58fbe55b08a9d4ac8d4"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "WireGuardKit",
     platforms: [
         .macOS(.v10_14),
-        .iOS(.v12)
+        .iOS(.v14)
     ],
     products: [
         .library(name: "WireGuardKit", targets: ["WireGuardKit"])

--- a/Sources/WireGuardKitC/WireGuardKitC.h
+++ b/Sources/WireGuardKitC/WireGuardKitC.h
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright © 2018-2021 WireGuard LLC. All Rights Reserved.
 
+#include <sys/types.h>
+
 #include "key.h"
 #include "x25519.h"
 

--- a/Sources/WireGuardKitGo/Info.plist
+++ b/Sources/WireGuardKitGo/Info.plist
@@ -24,7 +24,5 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>MinimumOSVersion</key>
-	<string>14.0</string>
 </dict>
 </plist>

--- a/Sources/WireGuardKitGo/Info.plist
+++ b/Sources/WireGuardKitGo/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>23D60</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>WireGuardKitGo</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.opera.WireGuardKitGo</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>WireGuardKitGo</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Sources/WireGuardKitGo/Info.plist
+++ b/Sources/WireGuardKitGo/Info.plist
@@ -24,5 +24,7 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>MinimumOSVersion</key>
+	<string>15.0</string>	
 </dict>
 </plist>

--- a/Sources/WireGuardKitGo/Info.plist
+++ b/Sources/WireGuardKitGo/Info.plist
@@ -24,5 +24,7 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
Context

     The app crashes in String(cString:) when the WireGuard Go library invokes the log callback. The crash occurs in Swift's memory allocator (_xzm_xzone_malloc_freelist_outlined) on a cgo thread. Go's
      cgo threads lack proper thread-local storage setup for Swift's allocator, causing heap corruption or allocator failure.

     File to modify

     Sources/WireGuardKit/WireGuardAdapter.swift — line ~293-303

     Fix

     Copy the C string to a buffer and dispatch to a serial queue before creating Swift objects. Minimal change: wrap the string creation and handler call in a DispatchQueue call so Swift allocations
     happen on a known-good thread.